### PR TITLE
Extend theme to include color palette

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import reactLogo from "./assets/react.svg";
 import viteLogo from "/vite.svg";
 import "./App.css";
@@ -6,8 +5,6 @@ import "./App.css";
 import { Button } from "./components";
 
 function App() {
-  const [count, setCount] = useState(0);
-
   return (
     <div className="p-12">
       <div>
@@ -18,20 +15,18 @@ function App() {
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>
-      <h1 className="text-3xl font-bold">Hello world!</h1>
-      <div>
-        <button
-          className="rounded-full bg-slate-100 px-6 py-3"
-          onClick={() => setCount((count) => count + 1)}
-        >
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
+      <div className="border-solid border border-border-weak p-6 rounded-xl flex flex-col gap-4 items-start">
+        <h1 className="text-3xl text-text-default font-bold">Hello world!</h1>
+        <div>
+          <p className="text-text-default">
+            Edit <code>src/App.tsx</code> and save to test HMR
+          </p>
+        </div>
+        <p className="text-text-default">
+          Click on the Vite and React logos to learn more
         </p>
+        <Button label="Click me" onClick={() => console.log("clicked")} />
       </div>
-      <p className="">Click on the Vite and React logos to learn more</p>
-      <Button label="Click me" onClick={() => console.log("clicked")} />
     </div>
   );
 }

--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -2,15 +2,15 @@
 @tailwind components;
 
 .btn {
-  @apply bg-blue-500 text-white font-bold py-2 px-4 rounded;
+  @apply bg-brand text-white font-bold py-2 px-4 rounded;
 }
 
 .btn:hover {
-  @apply bg-blue-700;
+  @apply bg-brand-dark;
 }
 
 .btn:active {
-  @apply bg-blue-700;
+  @apply bg-brand-dark;
 }
 
 .btn:focus {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import {forwardRef} from "react";
+import { forwardRef } from "react";
 import "./Button.css";
 
 type ButtonProps = {
@@ -7,29 +7,17 @@ type ButtonProps = {
 };
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    {
-      label, 
-      onClick,
-      ...rest
-    }: ButtonProps, 
-    ref
-  ): JSX.Element => {
-  
+  ({ label, onClick, ...rest }: ButtonProps, ref): JSX.Element => {
     const content = label;
 
-  return (
-    <button 
-      ref={ref}
-      className="btn"
-      onClick={onClick} 
-      {...rest}
-    >
-      {content}
-    </button>
-  );
-});
+    return (
+      <button ref={ref} className="btn" onClick={onClick} {...rest}>
+        {content}
+      </button>
+    );
+  }
+);
 
 Button.displayName = "Button";
 
-export {Button};
+export { Button };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,23 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx, html}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        brand: "#E31C5F",
+        "brand-dark": "#D70466",
+        background: "#FFFFFF",
+        border: {
+          strong: "#222222",
+          default: "#A0A0A0",
+          weak: "#CCCCCC",
+        },
+        text: {
+          default: "#222222",
+          weak: "#717171",
+        },
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
Extending theme to include color palette. Down the line, we may want to move this to the root level as opposed to extend to restrict the application to our palette only. For the time being, extending as we form the final color palette.